### PR TITLE
use embeded migemo if there is not cmigemo in $PATH

### DIFF
--- a/autoload/vital/_incsearch_migemo/Migemo/Interactive.vim
+++ b/autoload/vital/_incsearch_migemo/Migemo/Interactive.vim
@@ -46,14 +46,14 @@ endfunction
 
 
 function! s:generate_regexp(word)
+	if has("migemo")
+		return s:Migemo.generate_regexp(a:word)
+	endif
 	if !exists("s:cmigemo")
 		call s:_init()
 	endif
 	if a:word ==# ""
 		return ""
-	endif
-	if has("migemo")
-		return s:Migemo.generate_regexp(a:word)
 	endif
 	call s:cmigemo.input(a:word)
 	return matchstr(s:cmigemo.get(), 'PATTERN: \zs.*\ze[\r\n]$')


### PR DESCRIPTION
Kaoriya 版で $PATH に cmigemo.exe が無いとエラーで検索できません
cmigemo の初期化前にKaoriya 版の組み込み migemo を使うよう
patch を書いてみましたがいかがでしょうか？
